### PR TITLE
fix(home): add spacing between attendance name and code in autocomplete

### DIFF
--- a/src/app/pages/main/home/home.component.scss
+++ b/src/app/pages/main/home/home.component.scss
@@ -58,6 +58,7 @@
   &__code {
     font-size: 0.75rem;
     opacity: 0.5;
+    margin-left: 0.5rem;
   }
 }
 


### PR DESCRIPTION
<img width="1199" height="222" alt="image" src="https://github.com/user-attachments/assets/0f839a06-14d2-4dc4-a0cf-45c3eca3be29" />
